### PR TITLE
Add parse tests for number of nfa states

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ utils.o: utils.c utils.h
 
 ## Testing
 
-tests: test regex_test.so
+tests: test regex_test.so parse_test.so
 
 test: test.o list.o
 	$(CC) $(CCFLAGS) $(INCLUDE) $(T_LDFLAGS) $(TESTDIR)/test.o list.o -o $(OUTDIR)/$@
@@ -47,6 +47,9 @@ test.o: $(TESTDIR)/test.c $(TESTDIR)/test.h
 	$(CC) $(CCFLAGS) $(INCLUDE) $< -o $(TESTDIR)/$@ -c
 
 regex_test.so: $(TESTDIR)/regex_test.c sregex.o parse.o dfa.o nfa.o list.o utils.o
+	$(CC) $(TF_CCFLAGS) $(INCLUDE) $(T_LDFLAGS) $^ -o ./$(TESTDIR)/$@
+
+parse_test.so: $(TESTDIR)/parse_test.c parse.o nfa.o list.o utils.o
 	$(CC) $(TF_CCFLAGS) $(INCLUDE) $(T_LDFLAGS) $^ -o ./$(TESTDIR)/$@
 
 ## Commands

--- a/nfa.c
+++ b/nfa.c
@@ -92,6 +92,8 @@ void init_epsilon(nfa_edge_t* edge) {
    edge->to = NULL;
 }
 
+int nfa_num_states(nfa_t* nfa) { return list_size(nfa->__nodes); }
+
 void free_nfa(nfa_t* nfa) {
    // Releaase all nodes in the nfa
    list_release(nfa->__nodes);

--- a/nfa.h
+++ b/nfa.h
@@ -26,7 +26,7 @@ struct nfa_edge {
       nfa_node_t* to;
 };
 
-// Constructors and setters
+// Constructors, getter/setters
 nfa_t* new_nfa();
 void nfa_consume_nodes(nfa_t*, nfa_t*);
 void nfa_set_start_end(nfa_t*, nfa_node_t*, nfa_node_t*);
@@ -35,6 +35,7 @@ nfa_node_t* new_node(int);
 nfa_edge_t* new_edges(int);
 void node_set_edges(nfa_node_t*, nfa_edge_t*, int);
 void init_epsilon(nfa_edge_t*);
+int nfa_num_states(nfa_t*);
 
 // Destructors
 void free_nfa(nfa_t*);

--- a/testing/parse_test.c
+++ b/testing/parse_test.c
@@ -1,0 +1,25 @@
+#include "parse.h"
+
+#include "test_file.h"
+
+TEST_CASE(creates_correct_number_states) {
+   nfa_t* nfa;
+
+   nfa = parse_regex_to_nfa("a");
+   assert_int_equal(nfa_num_states(nfa), 2);
+   free_nfa(nfa);
+
+   nfa = parse_regex_to_nfa("ab");
+   assert_int_equal(nfa_num_states(nfa), 4);
+   free_nfa(nfa);
+
+   nfa = parse_regex_to_nfa("a*");
+   assert_int_equal(nfa_num_states(nfa), 4);
+   free_nfa(nfa);
+
+   nfa = parse_regex_to_nfa("a|b");
+   assert_int_equal(nfa_num_states(nfa), 6);
+   free_nfa(nfa);
+}
+
+void on_register_tests(void) { REGISTER_TEST(creates_correct_number_states); }

--- a/testing/test_file.h
+++ b/testing/test_file.h
@@ -13,6 +13,8 @@
 #define assert_true(condition) __plugin_assert(condition, #condition, __FILE__, __func__, __LINE__);
 #define assert_false(condition) \
    __plugin_assert(!(condition), #condition, __FILE__, __func__, __LINE__);
+#define assert_int_equal(a, b) \
+   __plugin_assert((a) == (b), #a " == " #b, __FILE__, __func__, __LINE__);
 #define assert(condition) __plugin_assert(condition, #condition, __FILE__, __func__, __LINE__);
 
 // Main executeble API references (private)


### PR DESCRIPTION
Tests that the correct number of states are created for common patterns. When implementing additional functionality this regressed, so figured unit tests would help.